### PR TITLE
Fix/rossum sdk dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ To reinstall with newer version, run `pipx install . --force`.
 <span style="color:#004795"> **Initialize empty project and repository** </span>  
 
 1. Run `prd init <project_name>` which will initialize an empty GIT repository. You can also use `.` for the project name and use the current directory.
-2. Fill in the required credentials in the `credentials.json` file that was created in the project folder - either `source.token` (retrieved using /auth endpoint) or `source.username` and `source.password`.
-3. Fill in `source_api_base` in the `prd_config.yaml` file.
-4. If you are going to deploy the code to a different Rossum organization configure `target_api_base` and `use_same_org_as_target: false` in `prd_config.yaml` and either `target.token` or `target.username` and `target.password` in `credentials.json`.
+2. Copy `credentials.template.json` to `credentials.json`
+3. Fill in the required credentials in the `credentials.json` file that was created in the project folder - either `source.token` (retrieved using /auth endpoint) or `source.username` and `source.password`.
+4. Fill in `source_api_base` in the `prd_config.yaml` file.
+5. If you are going to deploy the code to a different Rossum organization configure `target_api_base` and `use_same_org_as_target: false` in `prd_config.yaml` and either `target.token` or `target.username` and `target.password` in `credentials.json`.
 
 > ℹ️ This command creates local git repository. If you want to connect it to an existing remote repository, call `git remote add <reponame> <giturl>`. If you already have an existing remote repository, it might be easier to clone it from the remote and create an `credentials.json` file manually in the root folder.
 

--- a/project_rossum_deploy/commands/initialize.py
+++ b/project_rossum_deploy/commands/initialize.py
@@ -37,7 +37,7 @@ def init_project(name: Path):
         with open(name / ".gitignore", "a") as wf:
             wf.write(credentials_ignore_line)
 
-    credentials_path = name / "credentials.json"
+    credentials_path = name / "credentials.template.json"
     copy_dummy_credentials_file(credentials_path)
 
     config_path = name / "prd_config.yaml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.12"
 httpx = "^0.25.2"
-rossum-api = { git = "https://github.com/rossumai/rossum-sdk" }
+rossum-api = { git = "https://github.com/rossumai/rossum-sdk", rev = "v0.20.0" }
 click = "^8.1.7"
 pyyaml = "^6.0.1"
 anyio = "^4.2.0"


### PR DESCRIPTION
Hi. Yesterday's release v0.20.1 of https://github.com/rossumai/rossum-sdk/releases/tag/v0.20.1 broke the installation.

The error is "_ImportError: cannot import name 'Resource' from 'rossum_api.api_client_' " (which is because https://github.com/rossumai/rossum-sdk/commit/99ec60c1fa51dccc684b600b976608807b681e5b)

Pinning the dependency to v.0.20.0 solves the problem and the pipx install .  results in working deployment manager.