### PR TITLE
Fixes for AWS Bedrock

### DIFF
--- a/deployment_manager/commands/document/llm_helper.py
+++ b/deployment_manager/commands/document/llm_helper.py
@@ -3,6 +3,7 @@ import copy
 import boto3
 from botocore.config import Config
 import json
+import os
 
 
 MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
@@ -10,7 +11,8 @@ MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
 class LLMHelper:
     def __init__(self):
-        self.session = boto3.Session(profile_name="rossum-dev")
+        profile_name = os.environ.get("AWS_PROFILE") or "rossum-dev"
+        self.session = boto3.Session(profile_name=profile_name)
         config = Config(
             max_pool_connections=100,
             read_timeout=120,
@@ -18,7 +20,7 @@ class LLMHelper:
         )
 
         self.bedrock_runtime = self.session.client(
-            "bedrock-runtime", region_name="us-east-1", config=config
+            "bedrock-runtime", region_name="us-west-2", config=config
         )
 
         self.payload_basis = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ jmespath = "^1.0.1"
 ruamel-yaml = "^0.18.6"
 pydantic = "^2.9.2"
 questionary = "^2.0.1"
+boto3 = "^1.37.30"
 
 # Moved from `rossum_api` dependencies:
 tenacity = "^8.2.3"


### PR DESCRIPTION
Few fixes - default region, boto3 dependency and correct AWS_PROFILE env name loading with defaulting to "rossum-dev"