### PR TITLE
fix(deploy): Run updates sequentially in planning mode for proper CLI display

### DIFF
--- a/deployment_manager/commands/deploy/subcommands/run/hook_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/hook_release.py
@@ -69,7 +69,13 @@ class HookRelease(ObjectRelease):
                 request = self.upload(target_object=hook_copy, target=target)
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
 
             self.update_targets(results)
         except AttributeOverrideException as e:

--- a/deployment_manager/commands/deploy/subcommands/run/inbox_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/inbox_release.py
@@ -97,7 +97,14 @@ class InboxRelease(ObjectRelease):
                 )
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
+
             self.update_targets(results)
 
         except Exception as e:

--- a/deployment_manager/commands/deploy/subcommands/run/queue_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/queue_release.py
@@ -199,7 +199,14 @@ class QueueRelease(ObjectRelease):
                 request = self.upload(target_object=queue_copy, target=target)
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
+
             self.update_targets(results)
 
             if self.deploy_failed:

--- a/deployment_manager/commands/deploy/subcommands/run/rule_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/rule_release.py
@@ -85,7 +85,14 @@ class RuleRelease(ObjectRelease):
                 request = self.upload(target_object=rule_copy, target=target)
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
+
             self.update_targets(results)
         except Exception as e:
             display_error(

--- a/deployment_manager/commands/deploy/subcommands/run/schema_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/schema_release.py
@@ -99,7 +99,14 @@ class SchemaRelease(ObjectRelease):
                 request = self.upload(target_object=schema_copy, target=target)
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
+
             self.update_targets(results)
 
             await asyncio.gather(

--- a/deployment_manager/commands/deploy/subcommands/run/workspace_release.py
+++ b/deployment_manager/commands/deploy/subcommands/run/workspace_release.py
@@ -51,7 +51,13 @@ class WorkspaceRelease(ObjectRelease):
                 request = self.upload(target_object=ws_copy, target=target)
                 release_requests.append(request)
 
-            results = await asyncio.gather(*release_requests)
+            if self.plan_only:
+                results = []
+                # Run sequentially when planning because user may have to input things in the CLI
+                for request in release_requests:
+                    results.append(await request)
+            else:
+                results = await asyncio.gather(*release_requests)
 
             self.update_targets(results)
         except Exception as e:


### PR DESCRIPTION
Without this, if there were multiple targets, the user would get multiple prompts that were colliding. Now only one is shown.