### PR TITLE
deploy run: reference-replacer robustness, ignore engine agenda_id, log applied secrets

### DIFF
--- a/deployment_manager/commands/deploy/subcommands/run/deploy_objects/base_deploy_object.py
+++ b/deployment_manager/commands/deploy/subcommands/run/deploy_objects/base_deploy_object.py
@@ -237,6 +237,15 @@ class DeployObject(BaseModel):
         # asyncio.gather returns results in the same order as they were put in
         self.update_targets()
 
+    def _log_applied_secrets(self, sent_data: dict):
+        """Log (keys only, never values) that secrets from the secrets file were applied."""
+        secret_keys = sorted((sent_data.get("secrets") or {}).keys())
+        if secret_keys:
+            pprint(
+                f"  ↳ Applied {len(secret_keys)} secret(s) from the secrets file to {self.display_type} "
+                f"{self.display_label}: [purple]{', '.join(secret_keys)}[/purple]."
+            )
+
     async def create_remote(self, data_attribute: dict, target: Target = None):
         try:
             data = getattr(target, data_attribute)
@@ -252,6 +261,7 @@ class DeployObject(BaseModel):
             target.update_after_first_create()
 
             pprint(f"{settings.CREATE_PRINT_STR} {self.display_type}: {self.create_source_to_target_string(result)}.")
+            self._log_applied_secrets(create_copy)
         except Exception as e:
             display_error(
                 f"Error while creating {self.display_type} {self.display_label} ^",
@@ -276,6 +286,7 @@ class DeployObject(BaseModel):
             target.data_from_remote = result
 
             pprint(f"{settings.UPDATE_PRINT_STR} {self.display_type}: {self.create_source_to_target_string(result)}.")
+            self._log_applied_secrets(update_copy)
         except Exception as e:
             display_error(
                 f'Error while updating {self.display_type} {self.display_label} -> "{target.id}: {e}',

--- a/deployment_manager/commands/deploy/subcommands/run/deploy_objects/reference_replacer.py
+++ b/deployment_manager/commands/deploy/subcommands/run/deploy_objects/reference_replacer.py
@@ -135,11 +135,13 @@ class ReferenceReplacer:
                 continue
 
             for parent, key_in_parent, value in traverse_object(target_object, key, target_object[key]):
-                current_value = value
+                # Resolve every reference against the ORIGINAL value, then apply them in a single pass,
+                # so an ID written by one lookup entry cannot be re-matched by a later one.
+                replacements: dict[str, str] | None = {}
                 for source_id, types_dict in lookup_table.items():
-                    if not id_regexes[source_id].search(str(current_value)):
+                    if not id_regexes[source_id].search(str(value)):
                         continue
-                    elif f"{key}.{key_in_parent}" in self.EXACT_MATCH_PATHS and str(source_id) != str(current_value):
+                    elif f"{key}.{key_in_parent}" in self.EXACT_MATCH_PATHS and str(source_id) != str(value):
                         # Skip substring-only matches for paths like "actions.id" where partial ID replacement would corrupt values (e.g., UUIDs)
                         continue
 
@@ -147,11 +149,12 @@ class ReferenceReplacer:
                         display_warning(
                             f'Could not override source_id "{source_id}" to its target equivalent in {self.type.value} "{target_object_label}". No target IDs found.',
                         )
-                        self.remove_id_from_list(object=parent, key=key_in_parent, value=current_value)
+                        self.remove_id_from_list(object=parent, key=key_in_parent, value=value)
+                        replacements = None
                         break
 
                     reference_type = self._resolve_reference_type(
-                        key=key_in_parent, value=str(current_value), source_id=source_id, types_dict=types_dict
+                        key=key_in_parent, value=str(value), source_id=source_id, types_dict=types_dict
                     )
                     if reference_type is self.NOT_A_REFERENCE:
                         continue
@@ -159,7 +162,8 @@ class ReferenceReplacer:
                         display_warning(
                             f'Could not override source_id "{source_id}" to its target equivalent in {self.type.value} "{target_object_label}". There are different types of objects with the same ID ({list(types_dict.keys())}).',
                         )
-                        self.remove_id_from_list(object=parent, key=key_in_parent, value=current_value)
+                        self.remove_id_from_list(object=parent, key=key_in_parent, value=value)
+                        replacements = None
                         break
 
                     targets = types_dict[reference_type]
@@ -175,20 +179,22 @@ class ReferenceReplacer:
                                 f"For overriding source_id '{source_id}' in {self.type.value} '{target_object_label}', There are multiple target IDs that could be assigned. The first one was used.",
                             )
 
-                    current_value = self.replace_id_in_object(
-                        object=parent,
-                        key=key_in_parent,
-                        value=current_value,
-                        source_id=source_id,
-                        target_id=target_id,
+                    replacements[str(source_id)] = str(target_id)
+
+                if replacements:
+                    self.replace_ids_in_object(
+                        object=parent, key=key_in_parent, value=value, replacements=replacements
                     )
 
-    def replace_id_in_object(self, object: dict, key: str, value: str | int, source_id: int, target_id: int):
-        """Replace the source ID inside the value and return the new value (unchanged if the key is gone)."""
+    def replace_ids_in_object(self, object: dict, key: str, value: str | int, replacements: dict[str, str]):
+        """Replace all source IDs in the value in one pass; matching the original value means a written
+        target is never re-matched as another ID's source. Handles a scalar, a multi-reference string, or a list element."""
         if key not in object:
             return value
 
-        new_value = self._id_regex(source_id).sub(lambda _: str(target_id), str(value))
+        alternation = "|".join(re.escape(s) for s in sorted(replacements, key=len, reverse=True))
+        pattern = re.compile(rf"(?<![0-9A-Za-z])({alternation})(?![0-9A-Za-z])")
+        new_value = pattern.sub(lambda m: replacements[m.group(0)], str(value))
         # Convert value back to int if applicable
         # Only do it if the new ID can be converted - dummy references cannot for instance
         if isinstance(value, int) and new_value.isdigit():
@@ -202,6 +208,9 @@ class ReferenceReplacer:
             object[key] = new_value
 
         return new_value
+
+    def replace_id_in_object(self, object: dict, key: str, value: str | int, source_id: int, target_id: int):
+        return self.replace_ids_in_object(object, key, value, {str(source_id): str(target_id)})
 
     def remove_id_from_list(self, object: dict, key: str, value: str | int):
         if key not in object:

--- a/deployment_manager/commands/deploy/subcommands/run/deploy_objects/reference_replacer.py
+++ b/deployment_manager/commands/deploy/subcommands/run/deploy_objects/reference_replacer.py
@@ -8,11 +8,39 @@ from rossum_api.domain_logic.resources import Resource
 
 from deployment_manager.commands.deploy.subcommands.run.helpers import create_object_label, traverse_object
 from deployment_manager.commands.deploy.subcommands.run.models import LookupTable, ReverseLookupTable
-from deployment_manager.utils.consts import display_warning
+from deployment_manager.utils.consts import CustomResource, display_warning
 from deployment_manager.utils.functions import extract_id_from_url
 
 if TYPE_CHECKING:
     from deployment_manager.commands.deploy.subcommands.run.deploy_objects.base_deploy_object import DeployObject
+
+
+def _singular(resource_url_part: str) -> str:
+    if resource_url_part.endswith("es") and resource_url_part[:-2].endswith(("x", "s", "h", "z")):
+        return resource_url_part[:-2]
+    return resource_url_part.removesuffix("s")
+
+
+REFERENCE_TYPES: list[Resource | CustomResource] = [
+    Resource.Organization,
+    Resource.Workspace,
+    Resource.Queue,
+    Resource.Schema,
+    Resource.Inbox,
+    Resource.Hook,
+    Resource.Rule,
+    Resource.Engine,
+    Resource.EngineField,
+    Resource.EmailTemplate,
+    CustomResource.Label,
+    CustomResource.Workflow,
+    CustomResource.WorkflowStep,
+]
+REFERENCE_TYPE_BY_KEY: dict[str, Resource | CustomResource] = {
+    **{resource.value: resource for resource in REFERENCE_TYPES},
+    **{_singular(resource.value): resource for resource in REFERENCE_TYPES},
+}
+REFERENCE_KEY_NOISE_TOKENS = ("id", "ids", "url", "urls", "ref", "refs", "reference", "references")
 
 
 class ReferenceReplacer:
@@ -23,6 +51,8 @@ class ReferenceReplacer:
     # Paths (as "key.subkey") where reference IDs must match exactly in unstructured attributes replacer rather than as
     # substrings, to avoid corrupting values (e.g., UUIDs) that happen to contain the source ID.
     EXACT_MATCH_PATHS = ["actions.id"]
+
+    NOT_A_REFERENCE = object()
 
     def __init__(self, parent_object_reference: DeployObject, type: Resource):
         self.parent_object_reference = parent_object_reference
@@ -36,6 +66,57 @@ class ReferenceReplacer:
         """Check if an ID is a valid numeric ID (not a dummy UUID)."""
         return isinstance(id_val, int) or (isinstance(id_val, str) and id_val.isdigit())
 
+    @staticmethod
+    def _id_regex(source_id: int | str) -> re.Pattern:
+        """Match the ID only when it is not glued to another alphanumeric character."""
+        return re.compile(rf"(?<![0-9A-Za-z]){re.escape(str(source_id))}(?![0-9A-Za-z])")
+
+    @staticmethod
+    def _replace_id_in_url(url: str, target_id: str) -> str:
+        """Swap the object ID (the last URL path segment) for the target one."""
+        base, _, _ = url.rpartition("/")
+        return f"{base}/{target_id}" if base else target_id
+
+    @classmethod
+    def _reference_type_from_value(cls, value: str, source_id: int | str) -> Resource | CustomResource | None:
+        """Infer what the ID refers to from a URL-like value (e.g., ".../hooks/1" -> Resource.Hook)."""
+        for resource in REFERENCE_TYPES:
+            if re.search(rf"(?:^|/){resource.value}/{re.escape(str(source_id))}(?![0-9])", value):
+                return resource
+        return None
+
+    @classmethod
+    def _reference_type_from_key(cls, key: str) -> Resource | CustomResource | None:
+        """Infer what the ID refers to from its key (e.g., "next_phase_hook_id" -> Resource.Hook)."""
+        tokens = str(key).lower().split("_")
+        while tokens and tokens[-1] in REFERENCE_KEY_NOISE_TOKENS:
+            tokens.pop()
+
+        for index in range(len(tokens)):
+            candidate = "_".join(tokens[index:])
+            if candidate in REFERENCE_TYPE_BY_KEY:
+                return REFERENCE_TYPE_BY_KEY[candidate]
+        return None
+
+    @classmethod
+    def _resolve_reference_type(
+        cls,
+        key: str,
+        value: str,
+        source_id: int | str,
+        types_dict: dict,
+    ):
+        """Resolve which type sharing this source ID is referenced (else NOT_A_REFERENCE, or None if ambiguous)."""
+        if len(types_dict) == 1:
+            return next(iter(types_dict))
+
+        inferred_type = cls._reference_type_from_value(value, source_id) or cls._reference_type_from_key(key)
+        if inferred_type is None:
+            return None if value.strip() == str(source_id) else cls.NOT_A_REFERENCE
+        if inferred_type in types_dict:
+            return inferred_type
+        return cls.NOT_A_REFERENCE
+
     def replace_references_in_unstructured_attributes(
         self,
         target_object_label: str,
@@ -47,90 +128,88 @@ class ReferenceReplacer:
         """
         Traverses selected "free-form" attributes like settings and replaces IDs of known objects using the lookup table
         """
+        id_regexes = {source_id: self._id_regex(source_id) for source_id in lookup_table}
+
         for key in self.IMPLICIT_OVERRIDE_KEYS:
             if key not in target_object:
                 continue
 
             for parent, key_in_parent, value in traverse_object(target_object, key, target_object[key]):
+                current_value = value
                 for source_id, types_dict in lookup_table.items():
-                    # source_id_regex = re.compile(f"(?<!\\w)({source_id})(?!\\w)")
-                    # if not re.search(source_id_regex, str(value)):
-                    # continue
-                    if str(source_id) not in str(value):
+                    if not id_regexes[source_id].search(str(current_value)):
                         continue
-                    elif f"{key}.{key_in_parent}" in self.EXACT_MATCH_PATHS and str(source_id) != str(value):
+                    elif f"{key}.{key_in_parent}" in self.EXACT_MATCH_PATHS and str(source_id) != str(current_value):
                         # Skip substring-only matches for paths like "actions.id" where partial ID replacement would corrupt values (e.g., UUIDs)
                         continue
 
-                    if len(types_dict.keys()) > 1:
-                        display_warning(
-                            f'Could not override source_id "{source_id}" to its target equivalent in {self.type.value} "{target_object_label}". There are different types of objects with the same ID ({list(types_dict.keys())}).',
-                        )
-                        self.remove_id_from_list(object=parent, key=key_in_parent, value=value)
-                        continue
-
-                    elif not len(types_dict.keys()):
+                    if not len(types_dict.keys()):
                         display_warning(
                             f'Could not override source_id "{source_id}" to its target equivalent in {self.type.value} "{target_object_label}". No target IDs found.',
                         )
-                        self.remove_id_from_list(object=parent, key=key_in_parent, value=value)
-                        continue
+                        self.remove_id_from_list(object=parent, key=key_in_parent, value=current_value)
+                        break
 
-                    targets = list(types_dict.values())[0]
+                    reference_type = self._resolve_reference_type(
+                        key=key_in_parent, value=str(current_value), source_id=source_id, types_dict=types_dict
+                    )
+                    if reference_type is self.NOT_A_REFERENCE:
+                        continue
+                    if reference_type is None:
+                        display_warning(
+                            f'Could not override source_id "{source_id}" to its target equivalent in {self.type.value} "{target_object_label}". There are different types of objects with the same ID ({list(types_dict.keys())}).',
+                        )
+                        self.remove_id_from_list(object=parent, key=key_in_parent, value=current_value)
+                        break
+
+                    targets = types_dict[reference_type]
                     # N:N objects -> objects are referenced in pairs
                     if num_targets == len(targets):
                         target_id = targets[target_object_index].id
-                        self.replace_id_in_object(
-                            object=parent,
-                            key=key_in_parent,
-                            value=value,
-                            source_id=source_id,
-                            target_id=target_id,
-                        )
                     # N:1 objects -> everything should be mapped to the first target ID
                     else:
                         target_id = targets[0].id
-                        self.replace_id_in_object(
-                            object=parent,
-                            key=key_in_parent,
-                            value=value,
-                            source_id=source_id,
-                            target_id=target_id,
-                        )
 
                         if len(targets) != 1:
                             display_warning(
                                 f"For overriding source_id '{source_id}' in {self.type.value} '{target_object_label}', There are multiple target IDs that could be assigned. The first one was used.",
                             )
 
+                    current_value = self.replace_id_in_object(
+                        object=parent,
+                        key=key_in_parent,
+                        value=current_value,
+                        source_id=source_id,
+                        target_id=target_id,
+                    )
+
     def replace_id_in_object(self, object: dict, key: str, value: str | int, source_id: int, target_id: int):
+        """Replace the source ID inside the value and return the new value (unchanged if the key is gone)."""
+        if key not in object:
+            return value
+
+        new_value = self._id_regex(source_id).sub(lambda _: str(target_id), str(value))
+        # Convert value back to int if applicable
+        # Only do it if the new ID can be converted - dummy references cannot for instance
+        if isinstance(value, int) and new_value.isdigit():
+            new_value = int(new_value)
+
         if isinstance(object[key], list):
-            if value in object[key]:
-                value_index = object[key].index(value)
-                new_value = str(value).replace(str(source_id), str(target_id))
-                # Convert value back to int if applicable
-                if isinstance(value, int) and new_value.isdigit():
-                    new_value = int(new_value)
-                object[key][value_index] = new_value
+            if value not in object[key]:
+                return value
+            object[key][object[key].index(value)] = new_value
         else:
-            new_value = str(value).replace(str(source_id), str(target_id))
-            # Convert value back to int if applicable
-            # Only do it if the new ID can be converted - dummy references cannot for instance
-            if isinstance(value, int) and new_value.isdigit():
-                new_value = int(new_value)
             object[key] = new_value
-        # Using lambdas for sub() because of quotes inside strings
-        # return re.sub(
-        #     regex,
-        #     lambda m: str(target_id) if m[0] == str(source_id) else m[0],
-        #     object_str,
-        # )
+
+        return new_value
 
     def remove_id_from_list(self, object: dict, key: str, value: str | int):
+        if key not in object:
+            return
+
         if isinstance(object[key], list):
-            value_index = object[key].index(value)
-            if value_index > -1:
-                del object[key][value_index]
+            if value in object[key]:
+                object[key].remove(value)
         else:
             del object[key]
 
@@ -177,7 +256,7 @@ class ReferenceReplacer:
             remote_url = selected_target.data_from_remote["url"]
             target_id_str = str(extract_id_from_url(remote_url))
 
-        new_url = source_dependency_url.replace(str(source_id), target_id_str)
+        new_url = self._replace_id_in_url(source_dependency_url, target_id_str)
         if source_base_url != target_base_url:
             new_url = new_url.replace(source_base_url, target_base_url)
         return new_url

--- a/deployment_manager/commands/deploy/subcommands/run/helpers.py
+++ b/deployment_manager/commands/deploy/subcommands/run/helpers.py
@@ -116,7 +116,7 @@ def traverse_object(parent_object: dict | None, parent_key: str, value: Any):
         for i in value:
             yield from traverse_object(parent_object, parent_key, i)
     elif isinstance(value, dict):
-        for k, v in value.items():
+        for k, v in list(value.items()):
             yield from traverse_object(value, k, v)
     elif isinstance(value, str) or isinstance(value, int):
         yield parent_object, parent_key, value

--- a/deployment_manager/utils/consts.py
+++ b/deployment_manager/utils/consts.py
@@ -273,6 +273,7 @@ class Settings:
         Resource.Inbox: ["email"],
         Resource.Queue: ["training_enabled"],
         Resource.Hook: ["guide", "status"],
+        Resource.Engine: ["agenda_id"],
         Resource.Organization: [
             "organization_group",
             "users",

--- a/tests/unit/deploy/run/test_reference_replacer.py
+++ b/tests/unit/deploy/run/test_reference_replacer.py
@@ -43,9 +43,10 @@ class TestReplaceBaseUrl:
     def test_same_base(self):
         rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=Resource.Hook)
         url = "https://src.rossum.app/api/v1/hooks/500001"
-        assert rr.replace_base_url(
-            url, "https://src.rossum.app/api/v1", "https://tgt.rossum.app/api/v1"
-        ) == "https://tgt.rossum.app/api/v1/hooks/500001"
+        assert (
+            rr.replace_base_url(url, "https://src.rossum.app/api/v1", "https://tgt.rossum.app/api/v1")
+            == "https://tgt.rossum.app/api/v1/hooks/500001"
+        )
 
     def test_no_replacement(self):
         rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=Resource.Hook)
@@ -467,3 +468,186 @@ class TestReplaceUnstructuredAttributes:
             num_targets=1,
         )
         assert target_object["actions"][0]["id"] == "99"
+
+
+class TestAmbiguousSourceIds:
+    """Source objects of different types can share the same numeric ID (e.g. hook 1 and rule 1)."""
+
+    @staticmethod
+    def _ambiguous_lookup(source_id=1, hook_target=90, rule_target=91):
+        lut = defaultdict(dict)
+        lut[source_id][Resource.Hook] = [_make_target(hook_target)]
+        lut[source_id][Resource.Rule] = [_make_target(rule_target)]
+        return lut
+
+    def _replace(self, target_object, lookup_table):
+        rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=Resource.Hook)
+        rr.replace_references_in_unstructured_attributes(
+            target_object_label="hook label",
+            target_object=target_object,
+            lookup_table=lookup_table,
+            target_object_index=0,
+            num_targets=1,
+        )
+        return target_object
+
+    def test_ids_embedded_in_other_numbers_are_ignored(self):
+        target_object = {
+            "settings": {
+                "sorting_queues": {"ACV": 8917, "EU1": 8917},
+                "max_size_kb": 51200,
+                "gsc_endpoint": "https://dhl.rossum.app/svc/shipment-dev/api/v1/uwc/next_stage",
+            }
+        }
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert result["settings"] == {
+            "sorting_queues": {"ACV": 8917, "EU1": 8917},
+            "max_size_kb": 51200,
+            "gsc_endpoint": "https://dhl.rossum.app/svc/shipment-dev/api/v1/uwc/next_stage",
+        }
+
+    def test_type_resolved_from_key(self):
+        target_object = {"settings": {"next_phase_hook_id": "1"}}
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert result["settings"]["next_phase_hook_id"] == "90"
+
+    def test_type_resolved_from_url(self):
+        target_object = {"settings": {"target": "https://src.rossum.app/api/v1/rules/1"}}
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert result["settings"]["target"] == "https://src.rossum.app/api/v1/rules/91"
+
+    def test_reference_to_type_not_deployed_under_the_id_is_left_alone(self):
+        target_object = {"settings": {"queue_id": "1"}}
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert result["settings"]["queue_id"] == "1"
+
+    def test_warns_and_removes_only_when_truly_ambiguous(self, capsys):
+        target_object = {"settings": {"some_ref": "1"}}
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert "some_ref" not in result["settings"]
+        assert "There are different types of objects with the same ID" in capsys.readouterr().out
+
+    def test_ambiguous_id_inside_a_larger_value_is_left_alone(self, capsys):
+        target_object = {"settings": {"template": ['  "sequenceNumber": 1,', "  }"]}}
+        result = self._replace(target_object, self._ambiguous_lookup())
+        assert result["settings"]["template"] == ['  "sequenceNumber": 1,', "  }"]
+        assert "Could not override" not in capsys.readouterr().out
+
+    def test_unambiguous_id_still_replaced(self):
+        target_object = {"settings": {"whatever": 1}}
+        result = self._replace(target_object, _make_lookup(1, Resource.Hook, [_make_target(90)]))
+        assert result["settings"]["whatever"] == 90
+
+
+class TestReferenceTypeInference:
+    @pytest.mark.parametrize(
+        "key,expected",
+        [
+            ("next_phase_hook_id", Resource.Hook),
+            ("exporter_hook_id", Resource.Hook),
+            ("hooks", Resource.Hook),
+            ("sorting_queues", Resource.Queue),
+            ("queue", Resource.Queue),
+            ("email_template_id", Resource.EmailTemplate),
+            ("schema_id", Resource.Schema),
+            ("engine_field_ids", Resource.EngineField),
+            ("inbox", Resource.Inbox),
+            ("some_ref", None),
+            ("id", None),
+            ("case_id", None),
+        ],
+    )
+    def test_from_key(self, key, expected):
+        assert ReferenceReplacer._reference_type_from_key(key) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("https://src.rossum.app/api/v1/hooks/1", Resource.Hook),
+            ("https://src.rossum.app/api/v1/rules/1", Resource.Rule),
+            ("queues/1", Resource.Queue),
+            ("https://src.rossum.app/api/v1/hooks/11", None),
+            ("api/v1/uwc/next_stage", None),
+        ],
+    )
+    def test_from_value(self, value, expected):
+        assert ReferenceReplacer._reference_type_from_value(value, 1) == expected
+
+
+class TestMultipleReferencesInOneValue:
+    """A single value can match several source IDs - each step must work on the up-to-date value."""
+
+    def _replace(self, target_object, lookup_table, type=Resource.Organization):
+        rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=type)
+        rr.replace_references_in_unstructured_attributes(
+            target_object_label="org label",
+            target_object=target_object,
+            lookup_table=lookup_table,
+            target_object_index=0,
+            num_targets=1,
+        )
+        return target_object
+
+    def test_removed_key_is_not_replaced_afterwards(self):
+        """Regression: KeyError when a later source ID matched a value whose key was already removed."""
+        lut = defaultdict(dict)
+        # Source object with no target equivalent -> the key is removed
+        lut[1] = {}
+        # ...and a second, resolvable ID present in the very same value
+        lut[8914][Resource.Queue] = [_make_target(9914)]
+        target_object = {"metadata": {"some_ref": "1 https://src.rossum.app/api/v1/queues/8914"}}
+        result = self._replace(target_object, lut)
+        assert "some_ref" not in result["metadata"]
+
+    def test_removed_list_item_is_not_replaced_afterwards(self):
+        lut = defaultdict(dict)
+        lut[1] = {}
+        lut[8914][Resource.Queue] = [_make_target(9914)]
+        target_object = {"metadata": {"refs": ["1 https://src.rossum.app/api/v1/queues/8914", "keep"]}}
+        result = self._replace(target_object, lut)
+        assert result["metadata"]["refs"] == ["keep"]
+
+    def test_second_reference_in_the_same_value_is_replaced(self):
+        lut = defaultdict(dict)
+        lut[7][Resource.Organization] = [_make_target(77)]
+        lut[8914][Resource.Queue] = [_make_target(9914)]
+        target_object = {"metadata": {"path": "organizations/7/queues/8914"}}
+        result = self._replace(target_object, lut)
+        assert result["metadata"]["path"] == "organizations/77/queues/9914"
+
+    def test_url_reference_in_metadata_is_replaced(self):
+        """The uwc_inbox_queue_id shape from organization.json."""
+        lut = defaultdict(dict)
+        lut[1][Resource.Hook] = [_make_target(90)]
+        lut[1][Resource.Rule] = [_make_target(91)]
+        lut[8914][Resource.Queue] = [_make_target(9914)]
+        target_object = {"metadata": {"uwc_inbox_queue_id": "https://dhl.rossum.app/api/v1/queues/8914"}}
+        result = self._replace(target_object, lut)
+        assert result["metadata"]["uwc_inbox_queue_id"] == "https://dhl.rossum.app/api/v1/queues/9914"
+
+
+class TestReplaceIdInUrl:
+    def test_only_last_segment_is_replaced(self):
+        """Regression: source ID 1 must not turn "api/v1" into "api/v<target id>"."""
+        assert (
+            ReferenceReplacer._replace_id_in_url("https://dhl.rossum.app/api/v1/hooks/1", "15253")
+            == "https://dhl.rossum.app/api/v1/hooks/15253"
+        )
+
+    def test_webhooks_alias(self):
+        assert (
+            ReferenceReplacer._replace_id_in_url("https://dhl.rossum.app/api/v1/webhooks/1", "15253")
+            == "https://dhl.rossum.app/api/v1/webhooks/15253"
+        )
+
+    def test_id_repeated_in_path(self):
+        assert (
+            ReferenceReplacer._replace_id_in_url("https://x/api/v1/queues/19/queues/19", "2634")
+            == "https://x/api/v1/queues/19/queues/2634"
+        )
+
+    def test_dummy_target_id(self):
+        assert (
+            ReferenceReplacer._replace_id_in_url("https://x/api/v1/hooks/1", "<NEW COPY>[0](Hook - 1)")
+            == "https://x/api/v1/hooks/<NEW COPY>[0](Hook - 1)"
+        )

--- a/tests/unit/deploy/run/test_reference_replacer.py
+++ b/tests/unit/deploy/run/test_reference_replacer.py
@@ -651,3 +651,41 @@ class TestReplaceIdInUrl:
             ReferenceReplacer._replace_id_in_url("https://x/api/v1/hooks/1", "<NEW COPY>[0](Hook - 1)")
             == "https://x/api/v1/hooks/<NEW COPY>[0](Hook - 1)"
         )
+
+
+class TestNoCascadeAcrossLookupEntries:
+    """A target written for one lookup entry must not be re-matched as a later entry's source ID."""
+
+    @staticmethod
+    def _lut_100_200_300():
+        # 100 -> 200, and a separate source object 200 -> 300 (200 is both a target and a later source)
+        lut = defaultdict(dict)
+        lut[100][Resource.Hook] = [_make_target(200)]
+        lut[200][Resource.Hook] = [_make_target(300)]
+        return lut
+
+    def test_scalar_written_target_not_rematched(self):
+        rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=Resource.Hook)
+        obj = {"settings": {"some_hook_ref": 100}}
+        rr.replace_references_in_unstructured_attributes(
+            target_object_label="h",
+            target_object=obj,
+            lookup_table=self._lut_100_200_300(),
+            target_object_index=0,
+            num_targets=1,
+        )
+        # 100 maps to 200 and stays 200 (must NOT cascade to 300)
+        assert obj["settings"]["some_hook_ref"] == 200
+
+    def test_two_refs_in_one_string_replaced_simultaneously(self):
+        rr = ReferenceReplacer(parent_object_reference=_make_parent(), type=Resource.Hook)
+        obj = {"settings": {"some_hook_ref": "100 and 200"}}
+        rr.replace_references_in_unstructured_attributes(
+            target_object_label="h",
+            target_object=obj,
+            lookup_table=self._lut_100_200_300(),
+            target_object_index=0,
+            num_targets=1,
+        )
+        # original 100 -> 200, original 200 -> 300; the 200 written for 100 is not touched again
+        assert obj["settings"]["some_hook_ref"] == "200 and 300"

--- a/tests/unit/utils/test_consts.py
+++ b/tests/unit/utils/test_consts.py
@@ -49,6 +49,10 @@ class TestConstants:
     def test_queue_engine_attrs(self):
         assert set(QUEUE_ENGINE_ATTRIBUTES) == {"dedicated_engine", "generic_engine"}
 
+    def test_engine_agenda_id_is_non_diffed(self):
+        """agenda_id is environment-specific and must be ignored in diffs and not deployed."""
+        assert "agenda_id" in settings.DEPLOY_NON_DIFFED_KEYS.get(Resource.Engine, [])
+
 
 class TestApiSuffixRegex:
     def test_matches_standard_suffix(self):


### PR DESCRIPTION
Fixes and improvements to `deploy run`.

### 1. Boundary/type-safe reference-ID replacement (`fix`)
The unstructured-attribute reference replacer matched source IDs as bare substrings, which broke same-org deploys where objects of different types share an ID. Three observed symptoms, all fixed:
- **Faulty warnings + data loss** — "different types of objects with the same ID" was raised for values that merely contained the digit, then the key was deleted (e.g. dropping `"sequenceNumber": 1` from a payload template).
- **KeyError crash** — `traverse_object` iterated a dict while the caller deleted keys from it; a removed reference key was then revisited.
- **Corrupted hook URLs** — source id `1` rewrote `.../api/v1/hooks/1` into `.../api/v15253/hooks/15253`, rejected by the API with `400 Invalid hyperlink`.

Now: ID matching/replacement is boundary-aware; when several types share an ID the referenced type is inferred from the URL segment or the key name; URL references only rewrite the last path segment.

### 2. Ignore engine `agenda_id` in diffs and deploy (`fix`)
`agenda_id` is assigned per environment, so it always differs and was flagged on every object comparison. Added to `DEPLOY_NON_DIFFED_KEYS[Resource.Engine]` → stripped from both source and remote before comparison and never deployed.

### 3. Log when hook secrets are applied (`feat`)
Deploy applied `deploy_secrets` silently. After a successful hook create/update the run now logs that N secret(s) from the secrets file were applied — **keys only, never values**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
